### PR TITLE
update geo_ip_helper.py for db migration install

### DIFF
--- a/app/geo_ip_helper.py
+++ b/app/geo_ip_helper.py
@@ -6,12 +6,12 @@ from ipaddr import IPAddress
 from app import app
 from app.models import cfg_settings
 
-app.config["GEOIP_ASN_DATABASE_FILE"] = cfg_settings.Cfg_settings.get_setting("GEOIP_ASN_DATABASE_FILE")
+#app.config["GEOIP_ASN_DATABASE_FILE"] = cfg_settings.Cfg_settings.get_setting("GEOIP_ASN_DATABASE_FILE")
 if not app.config["GEOIP_ASN_DATABASE_FILE"]:
     app.config["GEOIP_ASN_DATABASE_FILE"] = os.getenv('GEOIP_ASN_DATABASE_FILE',
                                                       'data/GeoLite2-ASN.mmdb')
 
-app.config["GEOIP_CITY_DATABASE_FILE"] = cfg_settings.Cfg_settings.get_setting("GEOIP_CITY_DATABASE_FILE")
+#app.config["GEOIP_CITY_DATABASE_FILE"] = cfg_settings.Cfg_settings.get_setting("GEOIP_CITY_DATABASE_FILE")
 if not app.config["GEOIP_CITY_DATABASE_FILE"]:
     app.config["GEOIP_CITY_DATABASE_FILE"] = os.getenv('GEOIP_CITY_DATABASE_FILE',
                                                        'data/GeoLite2-City.mmdb')


### PR DESCRIPTION
`python manage.py db upgrade` during install doesn't work properly without these 2 lines commented out in the `app/geo_ip_helper.py` file