### PR TITLE
Issue #215, Add an option to maximize the artifact editing modal

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -149,3 +149,14 @@ span.glyphicon {
 }
 
 
+/* Bootstrap modal sizing overrides */
+@media (min-width: 768px) {
+    .modal-dialog {
+        width: auto;
+        margin: 10px;
+    }
+}
+@media (min-width: 992px) {
+    .modal-lg { width: 900px; }
+    .modal-dialog { margin: 30px auto; }
+}


### PR DESCRIPTION
I've modified the dynamic, screen width based sizing (bootstrap default) of all modals such that I've dropped the middle, kind'a narrow size between 768px and 992px. Now, as soon as the screen is narrower than 992px the modal will go full-screen.

![image](https://user-images.githubusercontent.com/4250750/47623289-0551b280-db10-11e8-8ea7-191b4a8eb1df.png)

I can, of course, make the modal go full-screen even on wider screens, or add a button to force full-screen at all times, but I haven't seen a case where the content of the modal would benefit from such width.

@pedramamini 
Please review and merge the PR if you're fine with this as a solution?