### PR TITLE
Issue #238, Left align content in details view

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -149,8 +149,10 @@ span.glyphicon {
 }
 
 
-/* Bootstrap modal sizing overrides */
+/* Bootstrap overrides */
+/* ... modal alignment */
 .modal-dialog { text-align: left; }
+/* ... modal sizing */
 @media (min-width: 768px) {
     .modal-dialog {
         width: auto;

--- a/app/static/css/codemirror.css
+++ b/app/static/css/codemirror.css
@@ -148,6 +148,8 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
   overflow: hidden;
   background: white;
   color: black;
+  border: 1px solid #ccc;
+  border-radius: 4px;
 }
 
 .CodeMirror-scroll {

--- a/app/static/views/c2dns/c2dns.html
+++ b/app/static/views/c2dns/c2dns.html
@@ -37,7 +37,7 @@
                 </div>
 
                 <div class="form-group">
-                    <label>Domain Name:</label>
+                    <label>Domain Name</label>
                     <span class="error" ng-show="form.domain_name.$error.minlength">Must be at least  characters.</span>
                     <span class="error"
                           ng-show="form.domain_name.$error.maxlength">Must be at most 2048 characters.</span>
@@ -49,14 +49,14 @@
 
 
                 <div class="form-group" ng-if="c2dns.date_created">
-                    <label>Date Created:</label>
+                    <label>Date Created</label>
 
                     <label type="text" class="form-control" name="date_created"
                            ng-model="c2dns.date_created">{{ c2dns.date_created }}</label>
                 </div>
 
                 <div class="form-group" ng-if="c2dns.date_modified">
-                    <label>Date Modified:</label>
+                    <label>Date Modified</label>
 
                     <label type="text" class="form-control" name="date_modified"
                            ng-model="c2dns.date_modified">{{ c2dns.date_modified }}</label>
@@ -64,7 +64,7 @@
 
 
                 <div class="form-group">
-                    <label>State:</label>
+                    <label>State</label>
                     <span class="error text-danger">*</span>
 
                     <ui-select ng-model="c2dns.state" name="state">
@@ -79,7 +79,7 @@
                 </div>
 
                 <div class="form-group">
-                    <label>Match Type:</label>
+                    <label>Match Type</label>
 
                     <ui-select ng-model="c2dns.match_type">
                         <ui-select-match placeholder="Select a match type or press delete to clear..">
@@ -93,7 +93,7 @@
 
 
                 <div class="form-group">
-                    <label>Expiration Type:</label>
+                    <label>Expiration Type</label>
 
                     <input class="form-control" name="expiration_type"
                            ng-model="c2dns.expiration_type" ng-required="false"
@@ -105,7 +105,7 @@
                 </div>
 
                 <div class="form-group">
-                    <label>Expiration Timestamp:</label>
+                    <label>Expiration Timestamp</label>
 
                     <input class="form-control" name="expiration_timestamp"
                            ui-date="expiration_timestampDateOptions" ui-date-format="yy-mm-dd"
@@ -114,53 +114,53 @@
 
                 <!-- START DYNAMICALLY GENERATED CONTENT -->
                 <div class="form-group" ng-repeat="m in metadata[0].string" ng-if="c2dns.id">
-                    <label>{{ m.key }}:</label>
+                    <label>{{ m.key }}</label>
                     <span class="error text-danger" ng-if="m.required">*</span>
                     <input class="form-control" ng-model="c2dns.metadata_values[m.key].value"
                            ng-required="m.required"/>
                 </div>
 
                 <div class="form-group" ng-repeat="m in metadata[0].string" ng-if="!c2dns.id">
-                    <label>{{ m.key }}:</label>
+                    <label>{{ m.key }}</label>
                     <span class="error text-danger" ng-if="m.required">*</span>
                     <input class="form-control" ng-model="m.default" ng-required="m.required">
                 </div>
 
                 <div class="form-group" ng-repeat="m in metadata[0].integer" ng-if="c2dns.id">
-                    <label>{{ m.key }}:</label>
+                    <label>{{ m.key }}</label>
                     <span class="error text-danger" ng-if="m.required">*</span>
                     <input class="form-control" ng-model="c2dns.metadata_values[m.key].value" type="number"
                            ng-required="m.required"/>
                 </div>
 
                 <div class="form-group" ng-repeat="m in metadata[0].integer" ng-if="!c2dns.id">
-                    <label>{{ m.key }}:</label>
+                    <label>{{ m.key }}</label>
                     <span class="error text-danger" ng-if="m.required">*</span>
                     <input class="form-control" ng-model="m.default" type="number" ng-required="m.required">
                 </div>
 
                 <div class="form-group" ng-repeat="m in metadata[0].date" ng-if="c2dns.id">
-                    <label>{{ m.key }}:</label>
+                    <label>{{ m.key }}</label>
                     <span class="error text-danger" ng-if="m.required">*</span>
                     <input class="form-control" ng-model="c2dns.metadata_values[m.key].value" type="date"
                            ng-required="m.required" format-date/>
                 </div>
 
                 <div class="form-group" ng-repeat="m in metadata[0].date" ng-if="!c2dns.id">
-                    <label>{{ m.key }}:</label>
+                    <label>{{ m.key }}</label>
                     <span class="error text-danger" ng-if="m.required">*</span>
                     <input class="form-control" ng-model="m.default" type="date" ng-required="m.required" format-date>
                 </div>
 
                 <div class="form-group" ng-repeat="m in metadata[0].multiline_comment" ng-if="c2dns.id">
-                    <label>{{ m.key }}:</label>
+                    <label>{{ m.key }}</label>
                     <span class="error text-danger" ng-if="m.required">*</span>
                     <textarea class="form-control" ng-model="c2dns.metadata_values[m.key].value" rows="2"
                               ng-required="m.required"></textarea>
                 </div>
 
                 <div class="form-group" ng-repeat="m in metadata[0].multiline_comment" rows="2" ng-if="!c2dns.id">
-                    <label>{{ m.key }}:</label>
+                    <label>{{ m.key }}</label>
                     <span class="error text-danger" ng-if="m.required">*</span>
                     <textarea class="form-control" ng-model="m.default" ng-required="m.required"></textarea>
                 </div>
@@ -199,7 +199,7 @@
                 <!-- /START DYNAMICALLY GENERATED CONTENT -->
 
                 <div class="form-group">
-                    <label>Tags:</label>
+                    <label>Tags</label>
 
                     <tags-input ng-model="c2dns.tags" on-tag-added="addedTag($tag)" on-tag-removed="removedTag($tag)">
                         <auto-complete source="loadTags($query)"
@@ -211,6 +211,7 @@
                 </div>
 
                 <div class="form-group" ng-if="c2dns.id">
+                    <label>Comments ({{ c2dns.comments.length }})</label>
                     <div class="input-group">
                         <textarea class="form-control" placeholder="Add a comment..." rows="4"
                                   ng-model="c2dns.new_comment"></textarea>
@@ -221,9 +222,7 @@
                                     class="glyphicon glyphicon-plus"></span></button>
                         </span>
                     </div>
-
-                    <label>Comments ({{ c2dns.comments.length }})</label>
-                    <div style="padding-top:3px;">
+                    <div ng-if="c2dns.comments && c2dns.comments.length" style="padding-top:3px;">
                         <uib-accordion>
                             <div uib-accordion-group class="panel-default"
                                  heading="See comments">
@@ -239,6 +238,7 @@
                             </div>
                         </uib-accordion>
                     </div>
+                </div>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-default" ng-click="cancel()">Cancel

--- a/app/static/views/c2ip/c2ips.html
+++ b/app/static/views/c2ip/c2ips.html
@@ -98,7 +98,7 @@
                 </div>
 
                 <div class="form-group">
-                    <label>Expiration Type:</label>
+                    <label>Expiration Type</label>
                     <span class="error"
                           ng-show="form.expiration_type.$error.minlength">Must be at least  characters.</span>
                     <span class="error"
@@ -110,7 +110,7 @@
                 </div>
 
                 <div class="form-group">
-                    <label>Expiration Timestamp:</label>
+                    <label>Expiration Timestamp</label>
 
                     <input class="form-control" name="expiration_timestamp"
                            ui-date="expiration_timestampDateOptions" ui-date-format="yy-mm-dd"
@@ -119,53 +119,53 @@
 
                 <!-- START DYNAMICALLY GENERATED CONTENT -->
                 <div class="form-group" ng-repeat="m in metadata[0].string" ng-if="c2ip.id">
-                    <label>{{ m.key }}:</label>
+                    <label>{{ m.key }}</label>
                     <span class="error text-danger" ng-if="m.required">*</span>
                     <input class="form-control" ng-model="c2ip.metadata_values[m.key].value"
                            ng-required="m.required"/>
                 </div>
 
                 <div class="form-group" ng-repeat="m in metadata[0].string" ng-if="!c2ip.id">
-                    <label>{{ m.key }}:</label>
+                    <label>{{ m.key }}</label>
                     <span class="error text-danger" ng-if="m.required">*</span>
                     <input class="form-control" ng-model="m.default" ng-required="m.required">
                 </div>
 
                 <div class="form-group" ng-repeat="m in metadata[0].integer" ng-if="c2ip.id">
-                    <label>{{ m.key }}:</label>
+                    <label>{{ m.key }}</label>
                     <span class="error text-danger" ng-if="m.required">*</span>
                     <input class="form-control" ng-model="c2ip.metadata_values[m.key].value" type="number"
                            ng-required="m.required"/>
                 </div>
 
                 <div class="form-group" ng-repeat="m in metadata[0].integer" ng-if="!c2ip.id">
-                    <label>{{ m.key }}:</label>
+                    <label>{{ m.key }}</label>
                     <span class="error text-danger" ng-if="m.required">*</span>
                     <input class="form-control" ng-model="m.default" type="number" ng-required="m.required">
                 </div>
 
                 <div class="form-group" ng-repeat="m in metadata[0].date" ng-if="c2ip.id">
-                    <label>{{ m.key }}:</label>
+                    <label>{{ m.key }}</label>
                     <span class="error text-danger" ng-if="m.required">*</span>
                     <input class="form-control" ng-model="c2ip.metadata_values[m.key].value" type="date"
                            ng-required="m.required" format-date/>
                 </div>
 
                 <div class="form-group" ng-repeat="m in metadata[0].date" ng-if="!c2ip.id">
-                    <label>{{ m.key }}:</label>
+                    <label>{{ m.key }}</label>
                     <span class="error text-danger" ng-if="m.required">*</span>
                     <input class="form-control" ng-model="m.default" type="date" ng-required="m.required" format-date>
                 </div>
 
                 <div class="form-group" ng-repeat="m in metadata[0].multiline_comment" ng-if="c2ip.id">
-                    <label>{{ m.key }}:</label>
+                    <label>{{ m.key }}</label>
                     <span class="error text-danger" ng-if="m.required">*</span>
                     <textarea class="form-control" ng-model="c2ip.metadata_values[m.key].value" rows="2"
                               ng-required="m.required"></textarea>
                 </div>
 
                 <div class="form-group" ng-repeat="m in metadata[0].multiline_comment" rows="2" ng-if="!c2ip.id">
-                    <label>{{ m.key }}:</label>
+                    <label>{{ m.key }}</label>
                     <span class="error text-danger" ng-if="m.required">*</span>
                     <textarea class="form-control" ng-model="m.default" ng-required="m.required"></textarea>
                 </div>
@@ -204,7 +204,7 @@
                 <!-- /START DYNAMICALLY GENERATED CONTENT -->
 
                 <div class="form-group">
-                    <label>Tags:</label>
+                    <label>Tags</label>
 
                     <tags-input ng-model="c2ip.tags" on-tag-added="addedTag($tag)" on-tag-removed="removedTag($tag)">
                         <auto-complete source="loadTags($query)"
@@ -216,6 +216,7 @@
                 </div>
 
                 <div class="form-group" ng-if="c2ip.id">
+                    <label>Comments ({{ c2ip.comments.length }})</label>
                     <div class="input-group">
                         <textarea class="form-control" placeholder="Add a comment..." rows="4"
                                   ng-model="c2ip.new_comment"></textarea>
@@ -226,9 +227,7 @@
                                     class="glyphicon glyphicon-plus"></span></button>
                         </span>
                     </div>
-
-                    <label>Comments ({{ c2ip.comments.length }})</label>
-                    <div style="padding-top:3px;">
+                    <div ng-if="c2ip.comments && c2ip.comments.length" style="padding-top:3px;">
                         <uib-accordion>
                             <div uib-accordion-group class="panel-default"
                                  heading="See comments">
@@ -244,7 +243,7 @@
                             </div>
                         </uib-accordion>
                     </div>
-
+                </div>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-default" ng-click="cancel()">Cancel

--- a/app/static/views/tasks/tasks.html
+++ b/app/static/views/tasks/tasks.html
@@ -36,7 +36,7 @@
                 </div>
 
                 <div class="form-group">
-                    <label>Title:</label>
+                    <label>Title</label>
                     <span class="error text-danger">*</span>
                     <input type="text" class="form-control" name="title"
                            ng-model="task.title" ng-required="true"
@@ -45,14 +45,14 @@
 
 
                 <div class="form-group" ng-if="task.date_created">
-                    <label>Date Created:</label>
+                    <label>Date Created</label>
 
                     <label type="text" class="form-control" name="date_created"
                            ng-model="task.date_created">{{ task.date_created }}</label>
                 </div>
 
                 <div class="form-group" ng-if="task.date_modified">
-                    <label>Date Modified:</label>
+                    <label>Date Modified</label>
 
                     <label type="text" class="form-control" name="date_modified"
                            ng-model="task.date_modified">{{ task.date_modified }}</label>
@@ -60,7 +60,7 @@
 
 
                 <div class="form-group">
-                    <label>State:</label>
+                    <label>State</label>
                     <span class="error text-danger" ng-if="!task.state">*</span>
 
                     <ui-select ng-model="task.state">
@@ -75,19 +75,20 @@
                 </div>
 
                 <div class="form-group">
-                    <label>Description:</label>
+                    <label>Description</label>
                     <span class="error text-danger">*</span>
                     <textarea class="form-control" placeholder="Enter description..." rows="6"
                               ng-model="task.description" ng-required="true"></textarea>
                 </div>
 
                 <div class="form-group">
-                    <label>Final Artifact:</label>
+                    <label>Final Artifact</label>
                     <textarea class="form-control" placeholder="Enter final artifact..." rows="6"
                               ng-model="task.final_artifact"></textarea>
                 </div>
 
                 <div class="form-group" ng-if="task.id">
+                    <label>Comments ({{ task.comments.length }})</label>
                     <div class="input-group">
                         <textarea class="form-control" placeholder="Add a comment..." rows="4"
                                   ng-model="task.new_comment"></textarea>
@@ -98,9 +99,7 @@
                                     class="glyphicon glyphicon-plus"></span></button>
                         </span>
                     </div>
-
-                    <label>Comments ({{ task.comments.length }})</label>
-                    <div style="padding-top:3px;">
+                    <div ng-if="task.comments && task.comments.length" style="padding-top:3px;">
                         <uib-accordion>
                             <div uib-accordion-group class="panel-default"
                                  heading="See comments">
@@ -116,7 +115,7 @@
                             </div>
                         </uib-accordion>
                     </div>
-
+                </div>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-primary pull-left" ng-click="extract_artifact()">Extract Artifact

--- a/app/static/views/yara_rule/yara_rules.html
+++ b/app/static/views/yara_rule/yara_rules.html
@@ -89,7 +89,7 @@
 
 
                 <div class="form-group">
-                    <label>Name:</label>
+                    <label>Name</label>
                     <span class="error" ng-show="form.name.$error.minlength">Must be at least  characters.</span>
                     <span class="error" ng-show="form.name.$error.maxlength">Must be at most 128 characters.</span>
                     <span class="error text-danger" ng-if="!yara_rule.name">*</span>
@@ -120,7 +120,7 @@
                 <BR>
 
                 <div class="form-group">
-                    <label>State:</label>
+                    <label>State</label>
                     <span class="error text-danger">*</span>
                     <ui-select ng-model="yara_rule.state" ng-required="true" on-select="">
                         <ui-select-match placeholder="Select a state or press delete to clear..">
@@ -134,7 +134,7 @@
                 </div>
 
                 <div class="form-group">
-                    <label>Category:</label>
+                    <label>Category</label>
                     <span class="error text-danger">*</span>
                     <ui-select ng-model="yara_rule.category" ng-required="true">
                         <ui-select-match placeholder="Select a category or press delete to clear...">
@@ -149,52 +149,52 @@
 
                 <!-- START DYNAMICALLY GENERATED CONTENT -->
                 <div class="form-group" ng-repeat="m in metadata[0].string" ng-if="yara_rule.id">
-                    <label>{{ m.key }}:</label>
+                    <label>{{ m.key }}</label>
                     <span class="error text-danger" ng-if="m.required">*</span>
                     <input class="form-control" ng-model="yara_rule.metadata_values[m.key].value"
                            ng-required="m.required"/>
                 </div>
 
                 <div class="form-group" ng-repeat="m in metadata[0].string" ng-if="!yara_rule.id">
-                    <label>{{ m.key }}:</label>
+                    <label>{{ m.key }}</label>
                     <span class="error text-danger" ng-if="m.required">*</span>
                     <input class="form-control" ng-model="m.default" ng-required="m.required">
                 </div>
 
                 <div class="form-group" ng-repeat="m in metadata[0].integer" ng-if="yara_rule.id">
-                    <label>{{ m.key }}:</label>
+                    <label>{{ m.key }}</label>
                     <span class="error text-danger" ng-if="m.required">*</span>
                     <input class="form-control" ng-model="yara_rule.metadata_values[m.key].value" type="number"
                            ng-required="m.required"/>
                 </div>
 
                 <div class="form-group" ng-repeat="m in metadata[0].integer" ng-if="!yara_rule.id">
-                    <label>{{ m.key }}:</label>
+                    <label>{{ m.key }}</label>
                     <span class="error text-danger" ng-if="m.required">*</span>
                     <input class="form-control" ng-model="m.default" type="number" ng-required="m.required">
                 </div>
 
                 <div class="form-group" ng-repeat="m in metadata[0].date" ng-if="yara_rule.id">
-                    <label>{{ m.key }}:</label>
+                    <label>{{ m.key }}</label>
                     <input class="form-control" ng-model="yara_rule.metadata_values[m.key].value" type="date"
                            ng-required="m.required" format-date/>
                 </div>
 
                 <div class="form-group" ng-repeat="m in metadata[0].date" ng-if="!yara_rule.id">
-                    <label>{{ m.key }}:</label>
+                    <label>{{ m.key }}</label>
                     <span class="error text-danger" ng-if="m.required">*</span>
                     <input class="form-control" ng-model="m.default" type="date" ng-required="m.required" format-date>
                 </div>
 
                 <div class="form-group" ng-repeat="m in metadata[0].multiline_comment" ng-if="yara_rule.id">
-                    <label>{{ m.key }}:</label>
+                    <label>{{ m.key }}</label>
                     <span class="error text-danger" ng-if="m.required">*</span>
                     <textarea class="form-control" ng-model="yara_rule.metadata_values[m.key].value" rows="2"
                               ng-required="m.required"></textarea>
                 </div>
 
                 <div class="form-group" ng-repeat="m in metadata[0].multiline_comment" rows="2" ng-if="!yara_rule.id">
-                    <label>{{ m.key }}:</label>
+                    <label>{{ m.key }}</label>
                     <span class="error text-danger" ng-if="m.required">*</span>
                     <textarea class="form-control" ng-model="m.default" ng-required="m.required"></textarea>
                 </div>
@@ -234,7 +234,7 @@
                 <!-- /START DYNAMICALLY GENERATED CONTENT -->
 
                 <div class="form-group">
-                    <label>Tags:</label>
+                    <label>Tags</label>
 
                     <tags-input ng-model="yara_rule.tags" on-tag-added="addedTag($tag)"
                                 on-tag-removed="removedTag($tag)" add-on-paste="true">
@@ -247,7 +247,7 @@
                 </div>
 
                 <div class="form-group" ng-if="yara_rule.id">
-
+                    <label>Comments ({{ yara_rule.comments.length }})</label>
                     <div class="input-group">
                         <textarea class="form-control" placeholder="Add a comment..." rows="4"
                                   ng-model="yara_rule.new_comment"></textarea>
@@ -258,9 +258,7 @@
                                     class="glyphicon glyphicon-plus"></span></button>
                         </span>
                     </div>
-
-                    <label>Comments ({{ yara_rule.comments.length }})</label>
-                    <div style="padding-top:3px;">
+                    <div ng-if="yara_rule.comments && yara_rule.comments.length" style="padding-top:3px;">
                         <uib-accordion>
                             <div uib-accordion-group class="panel-default"
                                  heading="See comments">
@@ -276,23 +274,22 @@
                             </div>
                         </uib-accordion>
                     </div>
-
-                </div>
-
-                <div class="form-group" ng-if="yara_rule.id">
-                    <div ngf-select="" ngf-drop="" ng-model="files" ngf-model-invalid="invalidFiles"
-                         ngf-change="upload(yara_rule.id, $files, $file, $newFiles, $duplicateFiles, $invalidFiles, $event)"
-                         ngf-model-options="modelOptionsObj" ngf-multiple="true" ngf-pattern="pattern"
-                         ngf-accept="acceptSelect" ngf-drag-over-class="dragover" ngf-validate="validateObj"
-                         ngf-allow-dir="true" class="drop-box" ngf-drop-available="dropAvailable">Select Files
-                        <span ng-show="dropAvailable"> or Drop Files</span>
-                    </div>
-                    <div ngf-no-file-drop>File Drag/Drop is not supported for this browser</div>
                 </div>
 
                 <div>
                     <label>Attached Files ({{ yara_rule.files.length }})</label>
-                    <div>
+                    <div ng-if="yara_rule.id">
+                        <div ngf-select="" ngf-drop="" ng-model="files" ngf-model-invalid="invalidFiles"
+                             ngf-change="upload(yara_rule.id, $files, $file, $newFiles, $duplicateFiles, $invalidFiles, $event)"
+                             ngf-model-options="modelOptionsObj" ngf-multiple="true" ngf-pattern="pattern"
+                             ngf-accept="acceptSelect" ngf-drag-over-class="dragover" ngf-validate="validateObj"
+                             ngf-allow-dir="true" class="drop-box" ngf-drop-available="dropAvailable">Select Files
+                            <span ng-show="dropAvailable"> or Drop Files</span>
+                        </div>
+                        <div ngf-no-file-drop>File Drag/Drop is not supported for this browser</div>
+                        <br />
+                    </div>
+                    <div ng-if="yara_rule.files && yara_rule.files.length">
                         <uib-accordion>
                             <div uib-accordion-group class="panel-default"
                                  heading="See files">
@@ -334,13 +331,12 @@
 
                 <div>
                     <label>Revisions ({{ yara_rule.revisions.length }})</label>
-                    <div style="padding-top:3px;">
+                    <div ng-if="yara_rule.revisions && yara_rule.revisions.length" style="padding-top:3px;">
                         <uib-accordion>
                             <div uib-accordion-group class="panel-default"
                                  heading="See revisions">
                                 <ul class="list-group">
-                                    <li class="list-group-item justify-content-between"
-                                    >
+                                    <li class="list-group-item justify-content-between">
                                         <div>
                                             <uib-accordion>
                                                 <div uib-accordion-group class="panel-default"


### PR DESCRIPTION
- [x] Fixed modal center-vs-left alignment issues
- [x] Make section labels consistent - all labels with or without ":" character
- [x] Make modal comments (and similar sections:
  - [x] Show the "Comments" label before the "Add a comment" textarea
![image](https://user-images.githubusercontent.com/4250750/47792098-8d57d800-dd1b-11e8-9fd7-e652d6ed8561.png)
  - [x] Show the "Attached files" label before the "Select or Drop filet" area
![image](https://user-images.githubusercontent.com/4250750/47792373-30105680-dd1c-11e8-8a7a-6ec05ac70c66.png)
  - [x] Only display "See comments" and similar links if/when there is something to see
![image](https://user-images.githubusercontent.com/4250750/47792114-99439a00-dd1b-11e8-8306-7e4d392ef864.png)
- [x] Add a border (same as other inputs) to CodeMirror syntax editors
![image](https://user-images.githubusercontent.com/4250750/47793006-8d58d780-dd1d-11e8-9d16-1d2ca3acd32f.png)
