### PR TITLE
Issue #241, Bootstrap client-side issue due to incompatible versions of angular and ngSanitize

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,8 +6,8 @@
     "angular-resource": "~1.2.13",
     "angular-route": "~1.2.13",
     "angular-ui-date": "~0.0.3",
-    "angular-sanitize": "^1.6.5",
-      "angular": "1.6.8",
+    "angular-sanitize": "1.6.8",
+    "angular": "1.6.8",
     "bootstrap-css": "3.3.7",
     "jquery": "~2.1.0",
     "lodash": "~2.4.1",
@@ -25,9 +25,9 @@
     "angular-block-ui": "^0.2.2",
     "angular-ui-grid": "^4.0.6",
     "ng-csv": "^0.3.6",
-      "ngclipboard": "^1.1.3",
-      "angular-hotkeys": "chieffancypants/angular-hotkeys#^1.7.0",
-      "angular-cookies": "^1.6.8"
+    "ngclipboard": "^1.1.3",
+    "angular-hotkeys": "chieffancypants/angular-hotkeys#^1.7.0",
+    "angular-cookies": "^1.6.8"
   },
   "devDependencies": {
     "angular-mocks": "~1.2.13",
@@ -35,6 +35,6 @@
   },
   "resolutions": {
     "angular-bootstrap": "2.5.0",
-      "angular": "1.6.8"
+    "angular": "1.6.8"
   }
 }


### PR DESCRIPTION
Upped ngSanitize version to 1.6.8 to get back compatibility with main angular module and fix bootstrapping issues ...

@hoboken515 
I'm guessing the bootstrap error only surfaced now because of this fix you made, which started pulling bower dependencies again: https://github.com/InQuest/ThreatKB/commit/cf260f2d0c61481d699febc869fcd455abe04a15