### PR TITLE
Fixed date-picker width styling

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -185,3 +185,9 @@ body.modals-full-screen .modal-dialog {
     .modal-lg { width: 900px; }
     .modal-dialog { margin: 30px auto; }
 }
+/* Datepicker (uib-datepicker) sizing */
+.form-group .input-group .uib-datepicker-popup.dropdown-menu {
+    width: 254px;
+    right: 0;
+    left: unset !important;
+}


### PR DESCRIPTION
Fixed date-picker styling issue (https://github.com/InQuest/ThreatKB/issues/321#issuecomment-483092055) where date-picker takes up full width of it's parent input component:

![image](https://user-images.githubusercontent.com/3661852/56105278-11380200-5f01-11e9-93c4-9e4d221ce2aa.png)

Fixed:

![image](https://user-images.githubusercontent.com/4250750/56161203-4740b900-5fc9-11e9-83f8-a5077065068f.png)