### PR TITLE
Issue #278, If the comment field is filled out, submit the save action for that field prior to saving the underlying artifact

### DIFF
--- a/app/static/js/c2dns/c2dns-controller.js
+++ b/app/static/js/c2dns/c2dns-controller.js
@@ -720,11 +720,21 @@ angular.module('ThreatKB')
             };
 
             $scope.ok = function () {
+                // Check if outstanding comment
+                if ($scope.c2dns.new_comment && $scope.c2dns.new_comment.trim() && confirm('There is a unsaved comment, do you wish to save it as well?')) {
+                    $scope.add_comment($scope.c2dns.id);
+                }
+                // Close modal
                 $window.document.title = "ThreatKB";
                 $uibModalInstance.close($scope.c2dns);
             };
 
             $scope.cancel = function () {
+                // Check if outstanding comment
+                if ($scope.c2dns.new_comment && $scope.c2dns.new_comment.trim() && confirm('There is a unsaved comment, do you wish to save it?')) {
+                    $scope.add_comment($scope.c2dns.id);
+                }
+                // Close modal
                 $window.document.title = "ThreatKB";
                 $uibModalInstance.dismiss('cancel');
             };

--- a/app/static/js/c2ip/c2ip-controller.js
+++ b/app/static/js/c2ip/c2ip-controller.js
@@ -716,11 +716,21 @@ angular.module('ThreatKB')
             };
 
             $scope.ok = function () {
+                // Check if outstanding comment
+                if ($scope.c2ip.new_comment && $scope.c2ip.new_comment.trim() && confirm('There is a unsaved comment, do you wish to save it as well?')) {
+                    $scope.add_comment($scope.c2ip.id);
+                }
+                // Close modal
                 $window.document.title = "ThreatKB";
                 $uibModalInstance.close($scope.c2ip);
             };
 
             $scope.cancel = function () {
+                // Check if outstanding comment
+                if ($scope.c2ip.new_comment && $scope.c2ip.new_comment.trim() && confirm('There is a unsaved comment, do you wish to save it?')) {
+                    $scope.add_comment($scope.c2ip.id);
+                }
+                // Close modal
                 $window.document.title = "ThreatKB";
                 $uibModalInstance.dismiss('cancel');
             };

--- a/app/static/js/tasks/tasks-controller.js
+++ b/app/static/js/tasks/tasks-controller.js
@@ -543,11 +543,21 @@ angular.module('ThreatKB')
             };
 
             $scope.ok = function () {
+                // Check if outstanding comment
+                if ($scope.task.new_comment && $scope.task.new_comment.trim() && confirm('There is a unsaved comment, do you wish to save it as well?')) {
+                    $scope.add_comment($scope.task.id);
+                }
+                // Close modal
                 $window.document.title = "ThreatKB";
                 $uibModalInstance.close($scope.task);
             };
 
             $scope.cancel = function () {
+                // Check if outstanding comment
+                if ($scope.task.new_comment && $scope.task.new_comment.trim() && confirm('There is a unsaved comment, do you wish to save it?')) {
+                    $scope.add_comment($scope.task.id);
+                }
+                // Close modal
                 $window.document.title = "ThreatKB";
                 $uibModalInstance.dismiss('cancel');
             };

--- a/app/static/js/yara_rule/yara_rule-controller.js
+++ b/app/static/js/yara_rule/yara_rule-controller.js
@@ -880,11 +880,21 @@ angular.module('ThreatKB')
             };
 
             $scope.ok = function () {
+                // Check if outstanding comment
+                if ($scope.yara_rule.new_comment && $scope.yara_rule.new_comment.trim() && confirm('There is a unsaved comment, do you wish to save it as well?')) {
+                    $scope.add_comment($scope.yara_rule.id);
+                }
+                // Close modal
                 $window.document.title = "ThreatKB";
                 $uibModalInstance.close($scope.yara_rule);
             };
 
             $scope.cancel = function () {
+                // Check if outstanding comment
+                if ($scope.yara_rule.new_comment && $scope.yara_rule.new_comment.trim() && confirm('There is a unsaved comment, do you wish to save it?')) {
+                    $scope.add_comment($scope.yara_rule.id);
+                }
+                // Close modal
                 $window.document.title = "ThreatKB";
                 $uibModalInstance.dismiss('cancel');
             };


### PR DESCRIPTION
On modal save or cancel, if there is a pending (unsaved) comment, user will be prompted to save it first ...

---

Handles issue #278, merges branch `issue/278-save-comment-on-modal-close`