### PR TITLE
Replaced <input type='date' /> with [uib-datepicker-popup] on Yara si…

### DIFF
--- a/app/static/js/yara_rule/yara_rule-controller.js
+++ b/app/static/js/yara_rule/yara_rule-controller.js
@@ -803,6 +803,15 @@ angular.module('ThreatKB')
                 return $location.absUrl();
             };
 
+            $scope.dateOptions = {
+                showWeeks: false,
+            };
+
+            $scope.datepickers = {};
+            $scope.openDatepicker = function(id) {
+                $scope.datepickers[id] = true;
+            };
+
             $scope.cfg_states = Cfg_states.query();
             $scope.cfg_category_range_mapping = CfgCategoryRangeMapping.query();
             $scope.do_not_bump_revision = true;
@@ -1038,6 +1047,15 @@ angular.module('ThreatKB')
 
             $scope.cancel = function () {
                 $uibModalInstance.dismiss('cancel');
+            };
+
+            $scope.dateOptions = {
+                showWeeks: false,
+            };
+
+            $scope.datepickers = {};
+            $scope.openDatepicker = function(id) {
+                $scope.datepickers[id] = true;
             };
 
             $scope.loadTags = function (query) {

--- a/app/static/views/yara_rule/yara_rules.html
+++ b/app/static/views/yara_rule/yara_rules.html
@@ -367,14 +367,34 @@
 
                 <div class="form-group" ng-repeat="m in metadata[0].date" ng-if="yara_rule.id">
                     <label>{{ m.key }}</label>
-                    <input class="form-control" ng-model="yara_rule.metadata_values[m.key].value" type="date"
-                           ng-required="m.required" format-date/>
+                    <!-- <input class="form-control" ng-model="yara_rule.metadata_values[m.key].value" type="date"
+                           ng-required="m.required" format-date/> -->
+                    <div class="input-group">
+                        <input type="text" class="form-control" ng-required="m.required"
+                            date-formatter uib-datepicker-popup="yyyy-MM-dd" alt-input-formats="['yyyy-MM-ddTHH:mm:ss']"
+                            datepicker-options="dateOptions" close-text="Close"
+                            is-open="datepickers[m.key]"
+                            ng-model="yara_rule.metadata_values[m.key].value" />
+                        <span class="input-group-btn">
+                            <button type="button" class="btn btn-default" ng-click="openDatepicker(m.key)"><i class="glyphicon glyphicon-calendar"></i></button>
+                        </span>
+                    </div>
                 </div>
 
                 <div class="form-group" ng-repeat="m in metadata[0].date" ng-if="!yara_rule.id">
                     <label>{{ m.key }}</label>
                     <span class="error text-danger" ng-if="m.required">*</span>
-                    <input class="form-control" ng-model="m.default" type="date" ng-required="m.required" format-date>
+                    <!-- <input class="form-control" ng-model="m.default" type="date" ng-required="m.required" format-date> -->
+                    <div class="input-group">
+                        <input type="text" class="form-control" ng-required="m.required"
+                            date-formatter uib-datepicker-popup="yyyy-MM-dd" alt-input-formats="['yyyy-MM-ddTHH:mm:ss']"
+                            datepicker-options="dateOptions" close-text="Close"
+                            is-open="datepickers[m.key]"
+                            ng-model="m.default" />
+                        <span class="input-group-btn">
+                            <button type="button" class="btn btn-default" ng-click="openDatepicker(m.key)"><i class="glyphicon glyphicon-calendar"></i></button>
+                        </span>
+                    </div>
                 </div>
 
                 <div class="form-group" ng-repeat="m in metadata[0].multiline_comment" ng-if="yara_rule.id">


### PR DESCRIPTION
Addendum to #364 - implements the same `<input type="date" />` to date-picker with UI Bootstrap replacement for Yara sign modal's as previously implemented for C2 modals' "Dynamically generated content" date-time values.

![image](https://user-images.githubusercontent.com/4250750/69090948-96f8ce80-0a49-11ea-95e7-36b8b98c80ad.png)
