### PR TITLE
Issue #374, Duplicate "Full screen" button in C2 DNS editing modal

### DIFF
--- a/app/static/views/c2dns/c2dns.html
+++ b/app/static/views/c2dns/c2dns.html
@@ -256,8 +256,6 @@
         <form name="form" novalidate
               class="ng-scope ng-invalid ng-invalid-required ng-dirty"
               ng-submit="ok()">
-            <a class="btn btn-sm btn-primary modal-fullscreen-button modal-fullscreen-button-abs-pos"
-               ng-click="toggleFullscreen()">Toggle full screen</a>
 
             <div class="modal-header">
                 <button type="button" class="close" ng-click="cancel()">&times;</button>


### PR DESCRIPTION
Fixed duplicated "Full screen" button:
![image](https://user-images.githubusercontent.com/4250750/73778342-59275e80-478b-11ea-8dc8-37f8d2aca58e.png)

--

Handles issue #374, merges branch `issue/374-duplicate-full-screen-button`