### PR TITLE
Fix Docker errors

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,3 +1,8 @@
+import os
+import sys
+import logging
+import datetime
+import distutils
 import functools
 
 from flask import Flask, abort, jsonify, request
@@ -10,14 +15,19 @@ from flask import make_response
 from functools import wraps, update_wrapper
 from flask_caching import Cache
 from flask_selfdoc import Autodoc
-import datetime
-import logging
-import os
-import distutils
 
 
 app = Flask(__name__, static_url_path='')
-app.config.from_object("config")
+
+if os.path.exists("testing_config.py") and not os.path.exists("config.py"):
+    app.config.from_object("testing_config")
+
+if os.path.exists("config.py"):
+    app.config.from_object("config")
+
+if not os.path.exists("config.py") and not os.path.exists("testing_config.py"):
+    print("Missing configuration settings")
+    sys.exit(1)
 
 if app.config.get('REDIS_CACHE_URL', None):
     cache = Cache(app, config={'CACHE_TYPE': 'redis', 'CACHE_REDIS_URL': app.config.get('REDIS_CACHE_URL')})

--- a/requirements.txt
+++ b/requirements.txt
@@ -93,7 +93,7 @@ sqlparse==0.4.2
 Tempita==0.5.2
 termcolor==1.1.0
 tabulate==0.8.9
-threatkb==0.1.1
+threatkb==1.0.0a2
 typing_extensions==4.4.0
 urllib3==1.26.9
 uWSGI==2.0.20

--- a/setup.py
+++ b/setup.py
@@ -4,28 +4,19 @@ setup(
     name='threatkb',
     version='0.1.1',
     description='Knowledge base workflow management for Yara rules and C2 artifacts (IP, DNS, SSL)',
-
     url='https://github.com/InQuest/ThreatKB',
-
     author='Daniel Tijerina, Rohan Kotian, David Cuellar, Ryan Shipp, Pedram Amini',
     author_email='ryan.ship@inquest.net, pedram@inquest.net',
-
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: InfoSec',
-
         'Licence :: ',
-
         'Programming Language :: Python :: 2.7',
     ],
-
     keywords='infosec yara c2 management',
-
     py_modules=['config'],
     packages=find_packages(exclude=['migrations', 'venv', 'contrib', 'docs', 'tests', 'build', 'dist', 'flask']),
-
-    license='...',
-
+    license='GPL-2.0',
     install_requires=[
         'alembic==1.7.7',
         'amqp==5.1.1',
@@ -90,18 +81,15 @@ setup(
         'WTForms==3.0.1',
         'yara-python==4.2.0'
     ],
-
     extra_require={
         'dev': [],
         'test': [],
     },
-
     include_package_data=True,
     package_data={
         'statics': ['app/static/*'],
         'config': ['config.py']
     },
-
     entry_points={
         'console_scripts': [
             'hunt = hunting.macro_hunter.cli:main',

--- a/testing_config.py
+++ b/testing_config.py
@@ -1,8 +1,7 @@
-import os
-import sys
+import os, sys, logging
 
-from flask_bcrypt import Bcrypt
 from flask import Flask
+from flask_bcrypt import Bcrypt
 
 SQL_PROTOCOL = os.getenv('SQL_PROTOCOL', 'mysql')
 SQL_HOST = os.getenv('SQL_HOST', '127.0.0.1')
@@ -19,16 +18,14 @@ SQLALCHEMY_DATABASE_URI = '{protocol}://{username}:{password}@{hostname}:{port}/
     database = SQL_DATABASE
 )
 
+LOGGING_LEVEL = getattr(logging, os.getenv('LOGGING_LEVEL', 'DEBUG'))
+
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 
 # Dummy user for tests.
 TEST_USER = 'admin'
 TEST_PASSWORD = 'password'
-
-app = Flask(__name__, static_url_path="")
-b = Bcrypt(app)
-TEST_PASSWORD_HASHED = b.generate_password_hash(TEST_PASSWORD)
-
+TEST_PASSWORD_HASHED = Bcrypt(Flask(__name__, static_url_path="")).generate_password_hash(TEST_PASSWORD)
 
 try:
     SQLALCHEMY_DATABASE_URI


### PR DESCRIPTION
Now includes an additional check for `config.py` or `testing_config.py`. This makes it so that when running `docker-compose up`, it no longer throws an error for missing files